### PR TITLE
support for ros-melodic

### DIFF
--- a/ur5_moveit_config/launch/move_group.launch
+++ b/ur5_moveit_config/launch/move_group.launch
@@ -36,7 +36,7 @@
 
   <!-- Sensors Functionality -->
   <include ns="move_group" file="$(find ur5_moveit_config)/launch/sensor_manager.launch.xml" if="$(arg allow_trajectory_execution)">
-    <arg name="moveit_sensor_manager" value="ur5" /> 
+    <arg name="moveit_sensor_manager" value="ur5" />
   </include>
 
   <!-- Start the actual move_group node/action server -->
@@ -50,7 +50,6 @@
 
     <!-- MoveGroup capabilities to load -->
     <param name="capabilities" value="move_group/MoveGroupCartesianPathService
-				      move_group/MoveGroupExecuteService
 				      move_group/MoveGroupKinematicsService
 				      move_group/MoveGroupMoveAction
 				      move_group/MoveGroupPickPlaceAction

--- a/ur5_robotiq85_moveit_config/launch/move_group.launch
+++ b/ur5_robotiq85_moveit_config/launch/move_group.launch
@@ -50,12 +50,16 @@
     <param name="jiggle_fraction" value="$(arg jiggle_fraction)" />
 
     <!-- load these non-default MoveGroup capabilities -->
-    <!--
-    <param name="capabilities" value="
-                  a_package/AwsomeMotionPlanningCapability
-                  another_package/GraspPlanningPipeline
-                  " />
-    -->
+    <param name="capabilities" value="move_group/MoveGroupCartesianPathService
+				      move_group/MoveGroupKinematicsService
+				      move_group/MoveGroupMoveAction
+				      move_group/MoveGroupPickPlaceAction
+				      move_group/MoveGroupPlanService
+				      move_group/MoveGroupQueryPlannersService
+				      move_group/MoveGroupStateValidationService
+				      move_group/MoveGroupGetPlanningSceneService
+				      move_group/ClearOctomapService
+				      " />
 
     <!-- inhibit these default MoveGroup capabilities -->
     <!--

--- a/ur_kinematics/include/ur_kinematics/ur_moveit_plugin.h
+++ b/ur_kinematics/include/ur_kinematics/ur_moveit_plugin.h
@@ -94,8 +94,6 @@
 #include <kdl/chainiksolvervel_pinv.hpp>
 #include <kdl/chainiksolverpos_nr_jl.hpp>
 #include <kdl/chainfksolverpos_recursive.hpp>
-#include <moveit/kdl_kinematics_plugin/chainiksolver_pos_nr_jl_mimic.hpp>
-#include <moveit/kdl_kinematics_plugin/chainiksolver_vel_pinv_mimic.hpp>
 #include <moveit/kdl_kinematics_plugin/joint_mimic.hpp>
 
 // MoveIt!


### PR DESCRIPTION
Unsupported KDL plugins and move_group capabilities were removed. Both the ur5_moveit_config and ur5_robotiq85_moveit_config packages are running on ROS Melodic. 